### PR TITLE
Increase number of tasks correctly

### DIFF
--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/RedisSinkConnector.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/RedisSinkConnector.java
@@ -43,7 +43,7 @@ public class RedisSinkConnector extends SinkConnector {
 
 	@Override
 	public List<Map<String, String>> taskConfigs(int maxTasks) {
-		return Collections.singletonList(props);
+		return Collections.nCopies(maxTasks, props);
 	}
 
 	@Override

--- a/core/redis-kafka-connect/src/test/java/com/redis/kafka/connect/RedisSinkConnectorTest.java
+++ b/core/redis-kafka-connect/src/test/java/com/redis/kafka/connect/RedisSinkConnectorTest.java
@@ -29,6 +29,7 @@ class RedisSinkConnectorTest {
 		props.put("field1", "value1");
 		connector.start(props);
 		Assertions.assertEquals(props, connector.taskConfigs(123).get(0));
+		Assertions.assertEquals(123, connector.taskConfigs(123).size());
 	}
 
 	@Test


### PR DESCRIPTION
Should solve https://github.com/redis-field-engineering/redis-kafka-connect/issues/27.

We should correctly scale connector tasks by creating n number of task configs.