### PR TITLE
[ENG-3663] Add PUBLISH functionality

### DIFF
--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/Publish.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/Publish.java
@@ -1,0 +1,23 @@
+package com.redis.kafka.connect.sink;
+
+import java.util.function.Function;
+
+import io.lettuce.core.RedisFuture;
+import io.lettuce.core.api.async.BaseRedisAsyncCommands;
+import com.redis.spring.batch.writer.operation.AbstractKeyWriteOperation;
+
+public class Publish<K, V, T> extends AbstractKeyWriteOperation<K, V, T> {
+
+    private Function<T, V> valueFunction;
+
+    public void setValueFunction(Function<T, V> function) {
+        this.valueFunction = function;
+    }
+
+    @Override
+    protected RedisFuture<Long> execute(BaseRedisAsyncCommands<K, V> commands, T item, K key) {
+        V value = valueFunction.apply(item);
+        return ((BaseRedisAsyncCommands<K, V>) commands).publish(key, value);
+    }
+
+}

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfig.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfig.java
@@ -25,7 +25,7 @@ import com.redis.kafka.connect.common.RedisConfig;
 public class RedisSinkConfig extends RedisConfig {
 
     public enum RedisCommand {
-        HSET, JSONSET, TSADD, SET, XADD, LPUSH, RPUSH, SADD, ZADD, DEL
+        HSET, JSONSET, TSADD, SET, XADD, LPUSH, RPUSH, SADD, ZADD, DEL, PUBLISH
     }
 
     public static final RedisSinkConfigDef CONFIG = new RedisSinkConfigDef();

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkTask.java
@@ -206,6 +206,11 @@ public class RedisSinkTask extends SinkTask {
                 Del<byte[], byte[], SinkRecord> del = new Del<>();
                 del.setKeyFunction(this::key);
                 return del;
+            case PUBLISH:
+                Publish<byte[], byte[], SinkRecord> publish = new Publish<>();
+                publish.setKeyFunction(this::key);
+                publish.setValueFunction(this::jsonValue);
+                return publish;
             default:
                 throw new ConfigException(RedisSinkConfigDef.COMMAND_CONFIG, config.getCommand());
         }


### PR DESCRIPTION
This PR adds the ability to use the Redis `PUBLISH` command to write payloads as JSON to Redis pubsub channels.