### PR TITLE
Add Support for Key TTL Setting for Sink Connector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG CP_VERSION=7.2.0
+ARG CP_VERSION=7.7.0
 ARG BASE_PREFIX=confluentinc
-ARG CONNECT_IMAGE=cp-server-connect
+ARG CONNECT_IMAGE=cp-kafka-connect
 
 FROM openjdk:18-jdk-slim AS build
 WORKDIR /root/redis-kafka-connect

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfig.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfig.java
@@ -37,6 +37,7 @@ public class RedisSinkConfig extends RedisConfig {
 	private final boolean multiExec;
 	private final int waitReplicas;
 	private final Duration waitTimeout;
+	private final long keyTTL;
 
 	public RedisSinkConfig(Map<?, ?> originals) {
 		super(new RedisSinkConfigDef(), originals);
@@ -48,6 +49,7 @@ public class RedisSinkConfig extends RedisConfig {
 		multiExec = Boolean.TRUE.equals(getBoolean(RedisSinkConfigDef.MULTIEXEC_CONFIG));
 		waitReplicas = getInt(RedisSinkConfigDef.WAIT_REPLICAS_CONFIG);
 		waitTimeout = Duration.ofMillis(getLong(RedisSinkConfigDef.WAIT_TIMEOUT_CONFIG));
+		keyTTL = getLong(RedisSinkConfigDef.KEY_TTL_CONFIG);
 	}
 
 	public Charset getCharset() {
@@ -78,12 +80,16 @@ public class RedisSinkConfig extends RedisConfig {
 		return waitTimeout;
 	}
 
+	public long getKeyTTL() {
+		return keyTTL;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result
-				+ Objects.hash(charset, keyspace, separator, multiExec, type, waitReplicas, waitTimeout);
+				+ Objects.hash(charset, keyspace, separator, multiExec, type, waitReplicas, waitTimeout, keyTTL);
 		return result;
 	}
 
@@ -98,7 +104,7 @@ public class RedisSinkConfig extends RedisConfig {
 		RedisSinkConfig other = (RedisSinkConfig) obj;
 		return Objects.equals(charset, other.charset) && Objects.equals(keyspace, other.keyspace)
 				&& Objects.equals(separator, other.separator) && multiExec == other.multiExec && type == other.type
-				&& waitReplicas == other.waitReplicas && waitTimeout == other.waitTimeout;
+				&& waitReplicas == other.waitReplicas && waitTimeout == other.waitTimeout && keyTTL == other.keyTTL;
 	}
 
 }

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfigDef.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfigDef.java
@@ -61,6 +61,12 @@ public class RedisSinkConfigDef extends RedisConfigDef {
 	public static final String TYPE_DOC = "Destination data structure: "
 			+ String.join(",", Stream.of(RedisType.values()).map(RedisType::name).toArray(String[]::new));
 
+	public static final String KEY_TTL_CONFIG = "redis.key.ttl";
+
+	public static final String KEY_TTL_CONFIG_DEFAULT = "-1";
+
+	public static final String KEY_TTL_CONFIG_DOC = "Time to live in seconds for the key. If not set, the record will not expire.";
+
 	protected static final Set<RedisType> MULTI_EXEC_COMMANDS = Stream
 			.of(RedisType.STREAM, RedisType.LIST, RedisType.SET, RedisType.ZSET).collect(Collectors.toSet());
 
@@ -81,6 +87,7 @@ public class RedisSinkConfigDef extends RedisConfigDef {
 		define(MULTIEXEC_CONFIG, Type.BOOLEAN, MULTIEXEC_DEFAULT, Importance.MEDIUM, MULTIEXEC_DOC);
 		define(WAIT_REPLICAS_CONFIG, Type.INT, WAIT_REPLICAS_DEFAULT, Importance.MEDIUM, WAIT_REPLICAS_DOC);
 		define(WAIT_TIMEOUT_CONFIG, Type.LONG, WAIT_TIMEOUT_DEFAULT, Importance.MEDIUM, WAIT_TIMEOUT_DOC);
+		define(KEY_TTL_CONFIG, Type.LONG, KEY_TTL_CONFIG_DEFAULT, Importance.MEDIUM, KEY_TTL_CONFIG_DOC);
 	}
 
 	@Override

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkTask.java
@@ -15,38 +15,6 @@
  */
 package com.redis.kafka.connect.sink;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
-
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.errors.RetriableException;
-import org.apache.kafka.connect.json.JsonConverter;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.sink.SinkTask;
-import org.apache.kafka.connect.storage.Converter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.batch.item.Chunk;
-import org.springframework.batch.item.ExecutionContext;
-import org.springframework.util.CollectionUtils;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -57,384 +25,387 @@ import com.redis.lettucemod.api.StatefulRedisModulesConnection;
 import com.redis.lettucemod.timeseries.Sample;
 import com.redis.spring.batch.item.redis.RedisItemWriter;
 import com.redis.spring.batch.item.redis.common.Operation;
-import com.redis.spring.batch.item.redis.writer.impl.Del;
-import com.redis.spring.batch.item.redis.writer.impl.Hset;
-import com.redis.spring.batch.item.redis.writer.impl.JsonSet;
-import com.redis.spring.batch.item.redis.writer.impl.Noop;
-import com.redis.spring.batch.item.redis.writer.impl.Rpush;
-import com.redis.spring.batch.item.redis.writer.impl.Sadd;
+import com.redis.spring.batch.item.redis.writer.impl.*;
 import com.redis.spring.batch.item.redis.writer.impl.Set;
-import com.redis.spring.batch.item.redis.writer.impl.TsAdd;
-import com.redis.spring.batch.item.redis.writer.impl.Xadd;
-import com.redis.spring.batch.item.redis.writer.impl.Zadd;
-
-import io.lettuce.core.AbstractRedisClient;
-import io.lettuce.core.KeyValue;
-import io.lettuce.core.RedisCommandTimeoutException;
-import io.lettuce.core.RedisConnectionException;
-import io.lettuce.core.RedisFuture;
-import io.lettuce.core.ScoredValue;
-import io.lettuce.core.StreamMessage;
+import io.lettuce.core.*;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.kafka.connect.storage.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.util.CollectionUtils;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 public class RedisSinkTask extends SinkTask {
 
-	private static final Logger log = LoggerFactory.getLogger(RedisSinkTask.class);
+    private static final Logger log = LoggerFactory.getLogger(RedisSinkTask.class);
 
-	private static final String OFFSET_KEY_FORMAT = "com.redis.kafka.connect.sink.offset.%s.%s";
+    private static final String OFFSET_KEY_FORMAT = "com.redis.kafka.connect.sink.offset.%s.%s";
 
-	private static final ObjectMapper objectMapper = objectMapper();
+    private static final ObjectMapper objectMapper = objectMapper();
 
-	private static final Collector<SinkOffsetState, ?, Map<String, String>> offsetCollector = Collectors
-			.toMap(RedisSinkTask::offsetKey, RedisSinkTask::offsetValue);
+    private static final Collector<SinkOffsetState, ?, Map<String, String>> offsetCollector = Collectors
+            .toMap(RedisSinkTask::offsetKey, RedisSinkTask::offsetValue);
 
-	private RedisSinkConfig config;
+    private RedisSinkConfig config;
 
-	private AbstractRedisClient client;
-	private StatefulRedisModulesConnection<String, String> connection;
-	private Converter jsonConverter;
-	private RedisItemWriter<byte[], byte[], SinkRecord> writer;
+    private AbstractRedisClient client;
+    private StatefulRedisModulesConnection<String, String> connection;
+    private Converter jsonConverter;
+    private RedisItemWriter<byte[], byte[], SinkRecord> writer;
 
-	@Override
-	public String version() {
-		return ManifestVersionProvider.getVersion();
-	}
+    private static ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
+        mapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
+        return mapper;
+    }
 
-	private static ObjectMapper objectMapper() {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-		mapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
-		mapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
-		return mapper;
-	}
+    private static String offsetKey(String topic, Integer partition) {
+        return String.format(OFFSET_KEY_FORMAT, topic, partition);
+    }
 
-	@Override
-	public void start(final Map<String, String> props) {
-		config = new RedisSinkConfig(props);
-		jsonConverter = new JsonConverter();
-		jsonConverter.configure(Collections.singletonMap("schemas.enable", "false"), false);
-		client = config.client();
-		connection = RedisModulesUtils.connection(client);
-		writer = RedisItemWriter.operation(ByteArrayCodec.INSTANCE, new ConditionalDel(operation(), del()));
-		writer.setClient(client);
-		writer.setMultiExec(config.isMultiExec());
-		writer.setWaitReplicas(config.getWaitReplicas());
-		writer.setWaitTimeout(config.getWaitTimeout());
-		writer.setPoolSize(config.getPoolSize());
-		writer.open(new ExecutionContext());
-		java.util.Set<TopicPartition> assignment = this.context.assignment();
-		if (CollectionUtils.isEmpty(assignment)) {
-			return;
-		}
-		Map<TopicPartition, Long> partitionOffsets = new HashMap<>(assignment.size());
-		for (SinkOffsetState state : offsetStates(assignment)) {
-			partitionOffsets.put(state.topicPartition(), state.offset());
-			log.info("Requesting offset {} for {}", state.offset(), state.topicPartition());
-		}
-		for (TopicPartition topicPartition : assignment) {
-			partitionOffsets.putIfAbsent(topicPartition, 0L);
-		}
-		this.context.offset(partitionOffsets);
-	}
+    private static String offsetKey(SinkOffsetState state) {
+        return offsetKey(state.topic(), state.partition());
+    }
 
-	private Operation<byte[], byte[], SinkRecord, Object> del() {
-		switch (config.getType()) {
-		case HASH:
-		case JSON:
-		case STRING:
-			return new Del<>(this::key);
-		default:
-			return new Noop<>();
-		}
-	}
+    private static String offsetValue(SinkOffsetState state) {
+        try {
+            return objectMapper.writeValueAsString(state);
+        } catch (JsonProcessingException e) {
+            throw new DataException("Could not serialize sink offset state", e);
+        }
+    }
 
-	private class ConditionalDel implements Operation<byte[], byte[], SinkRecord, Object> {
+    @Override
+    public String version() {
+        return ManifestVersionProvider.getVersion();
+    }
 
-		private final Predicate<SinkRecord> delPredicate = r -> r.value() == null;
-		private final Operation<byte[], byte[], SinkRecord, Object> write;
-		private final Operation<byte[], byte[], SinkRecord, Object> del;
+    @Override
+    public void start(final Map<String, String> props) {
+        config = new RedisSinkConfig(props);
+        jsonConverter = new JsonConverter();
+        jsonConverter.configure(Collections.singletonMap("schemas.enable", "false"), false);
+        client = config.client();
+        connection = RedisModulesUtils.connection(client);
+        writer = RedisItemWriter.operation(ByteArrayCodec.INSTANCE, new ConditionalDel(operation(), del()));
+        writer.setClient(client);
+        writer.setMultiExec(config.isMultiExec());
+        writer.setWaitReplicas(config.getWaitReplicas());
+        writer.setWaitTimeout(config.getWaitTimeout());
+        writer.setPoolSize(config.getPoolSize());
+        writer.open(new ExecutionContext());
+        java.util.Set<TopicPartition> assignment = this.context.assignment();
+        if (CollectionUtils.isEmpty(assignment)) {
+            return;
+        }
+        Map<TopicPartition, Long> partitionOffsets = new HashMap<>(assignment.size());
+        for (SinkOffsetState state : offsetStates(assignment)) {
+            partitionOffsets.put(state.topicPartition(), state.offset());
+            log.info("Requesting offset {} for {}", state.offset(), state.topicPartition());
+        }
+        for (TopicPartition topicPartition : assignment) {
+            partitionOffsets.putIfAbsent(topicPartition, 0L);
+        }
+        this.context.offset(partitionOffsets);
+    }
 
-		public ConditionalDel(Operation<byte[], byte[], SinkRecord, Object> delegate,
-				Operation<byte[], byte[], SinkRecord, Object> remove) {
-			this.write = delegate;
-			this.del = remove;
-		}
+    private Operation<byte[], byte[], SinkRecord, Object> del() {
+        switch (config.getType()) {
+            case HASH:
+            case JSON:
+            case STRING:
+                return new Del<>(this::key);
+            default:
+                return new Noop<>();
+        }
+    }
 
-		@Override
-		public List<RedisFuture<Object>> execute(RedisAsyncCommands<byte[], byte[]> commands,
-				Chunk<? extends SinkRecord> items) {
-			List<RedisFuture<Object>> futures = new ArrayList<>();
-			List<SinkRecord> toRemove = items.getItems().stream().filter(delPredicate).collect(Collectors.toList());
-			futures.addAll(del.execute(commands, new Chunk<>(toRemove)));
-			List<SinkRecord> toWrite = items.getItems().stream().filter(delPredicate.negate())
-					.collect(Collectors.toList());
-			futures.addAll(write.execute(commands, new Chunk<>(toWrite)));
-			return futures;
-		}
+    private Collection<SinkOffsetState> offsetStates(java.util.Set<TopicPartition> assignment) {
+        String[] partitionKeys = assignment.stream().map(this::offsetKey).toArray(String[]::new);
+        List<KeyValue<String, String>> values = connection.sync().mget(partitionKeys);
+        return values.stream().filter(KeyValue::hasValue).map(this::offsetState).collect(Collectors.toList());
+    }
 
-	}
+    private String offsetKey(TopicPartition partition) {
+        return offsetKey(partition.topic(), partition.partition());
+    }
 
-	private Collection<SinkOffsetState> offsetStates(java.util.Set<TopicPartition> assignment) {
-		String[] partitionKeys = assignment.stream().map(this::offsetKey).toArray(String[]::new);
-		List<KeyValue<String, String>> values = connection.sync().mget(partitionKeys);
-		return values.stream().filter(KeyValue::hasValue).map(this::offsetState).collect(Collectors.toList());
-	}
+    private SinkOffsetState offsetState(KeyValue<String, String> value) {
+        try {
+            return objectMapper.readValue(value.getValue(), SinkOffsetState.class);
+        } catch (JsonProcessingException e) {
+            throw new DataException("Could not parse sink offset state", e);
+        }
+    }
 
-	private String offsetKey(TopicPartition partition) {
-		return offsetKey(partition.topic(), partition.partition());
-	}
+    private Operation<byte[], byte[], SinkRecord, Object> operation() {
+        Operation<byte[], byte[], SinkRecord, Object> oper;
 
-	private SinkOffsetState offsetState(KeyValue<String, String> value) {
-		try {
-			return objectMapper.readValue(value.getValue(), SinkOffsetState.class);
-		} catch (JsonProcessingException e) {
-			throw new DataException("Could not parse sink offset state", e);
-		}
-	}
+        switch (config.getType()) {
+            case HASH -> oper = new Hset<>(this::key, this::map);
+            case JSON -> oper = new JsonSet<>(this::key, this::jsonValue);
+            case STRING -> oper = new Set<>(this::key, this::value);
+            case STREAM -> oper = new Xadd<>(this::collectionKey, this::streamMessages);
+            case LIST -> oper = new Rpush<>(this::collectionKey, this::members);
+            case SET -> oper = new Sadd<>(this::collectionKey, this::members);
+            case TIMESERIES -> oper = new TsAdd<>(this::collectionKey, this::samples);
+            case ZSET -> oper = new Zadd<>(this::collectionKey, this::scoredValues);
+            default -> throw new ConfigException(RedisSinkConfigDef.TYPE_CONFIG, config.getType());
+        }
 
-	private static String offsetKey(String topic, Integer partition) {
-		return String.format(OFFSET_KEY_FORMAT, topic, partition);
-	}
+        return new TTLSupport(oper);
+    }
 
-	private Operation<byte[], byte[], SinkRecord, Object> operation() {
-		Operation<byte[], byte[], SinkRecord, Object> op;
-		switch (config.getType()) {
-			case HASH:
-				op = new Hset<>(this::key, this::map);
-				break;
-			case JSON:
-				op = new JsonSet<>(this::key, this::jsonValue);
-				break;
-			case STRING:
-				op = new Set<>(this::key, this::value);
-				break;
-			case STREAM:
-				op = new Xadd<>(this::collectionKey, this::streamMessages);
-				break;
-			case LIST:
-				op = new Rpush<>(this::collectionKey, this::members);
-				break;
-			case SET:
-				op = new Sadd<>(this::collectionKey, this::members);
-				break;
-			case TIMESERIES:
-				op = new TsAdd<>(this::collectionKey, this::samples);
-				break;
-			case ZSET:
-				op = new Zadd<>(this::collectionKey, this::scoredValues);
-				break;
-			default:
-				throw new ConfigException(RedisSinkConfigDef.TYPE_CONFIG, config.getType());
-		}
-		if (config.getKeyTTL() > 0) {
-			op = new WithTTL(op, config.getKeyTTL(), this::key);
-		}
-		return op;
-	}
+    private class TTLSupport implements Operation<byte[], byte[], SinkRecord, Object> {
+        private final Operation<byte[], byte[], SinkRecord, Object> delegate;
 
-	private class WithTTL implements Operation<byte[], byte[], SinkRecord, Object> {
+        public TTLSupport(Operation<byte[], byte[], SinkRecord, Object> delegate) {
+            this.delegate = delegate;
+        }
 
-		private final Operation<byte[], byte[], SinkRecord, Object> delegate;
-		private final long keyTTL;
-		private final Function<SinkRecord, byte[]> keyExtractor;
+        @Override
+        public List<RedisFuture<Object>> execute(RedisAsyncCommands<byte[], byte[]> commands, Chunk<? extends SinkRecord> items) {
+            List<RedisFuture<Object>> futures = new ArrayList<>(delegate.execute(commands, items));
 
-		public WithTTL(Operation<byte[], byte[], SinkRecord, Object> delegate, long keyTTL, Function<SinkRecord, byte[]> keyExtractor) {
-			this.delegate = delegate;
-			this.keyTTL = keyTTL;
-			this.keyExtractor = keyExtractor;
-		}
+            for (SinkRecord record : items) {
+                byte[] key = determineKey(record);
+                long ttlFromRecord = extractTTLFromHeaders(record);
 
-		@Override
-		public List<RedisFuture<Object>> execute(RedisAsyncCommands<byte[], byte[]> commands, Chunk<? extends SinkRecord> items) {
-			List<RedisFuture<Object>> futures = new ArrayList<>(delegate.execute(commands, items));
-			if (keyTTL > 0) {
-				for (SinkRecord record : items) {
-					if (record.value() != null) {
-						byte[] key = keyExtractor.apply(record);
-						futures.add((RedisFuture<Object>) (RedisFuture<?>) commands.expire(key, keyTTL));
-						log.debug("");
-						log.debug("");
-						log.debug("");
-						log.debug("************* Redis key expired: {} **************", key);
-						log.debug("");
-						log.debug("");
-						log.debug("");
-					}
-				}
-			}
-			return futures;
-		}
-	}
+                if (ttlFromRecord > 0) {
+                    futures.add((RedisFuture<Object>) (RedisFuture<?>) commands.expire(key, ttlFromRecord));
+                } else if (config.getKeyTTL() > 0) {
+                    futures.add((RedisFuture<Object>) (RedisFuture<?>) commands.expire(key, config.getKeyTTL()));
+                }
+            }
 
-	private Collection<ScoredValue<byte[]>> scoredValues(SinkRecord sinkRecord) {
-		return Arrays.asList(ScoredValue.just(doubleValue(sinkRecord), member(sinkRecord)));
-	}
+            return futures;
+        }
 
-	private Collection<Sample> samples(SinkRecord sinkRecord) {
-		return Arrays.asList(Sample.of(longMember(sinkRecord), doubleValue(sinkRecord)));
-	}
+        private byte[] determineKey(SinkRecord record) {
+            return switch (config.getType()) {
+                case STREAM, LIST, SET, ZSET, TIMESERIES -> collectionKey(record);
+                default -> key(record);
+            };
+        }
 
-	private byte[] value(SinkRecord sinkRecord) {
-		return bytes("value", sinkRecord.value());
-	}
+        private long extractTTLFromHeaders(SinkRecord record) {
+            for (Header header : record.headers()) {
+                if (header.key().equals(RedisSinkConfigDef.KEY_TTL_CONFIG)) {
+                    try {
+                        return Long.parseLong(header.value().toString());
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid TTL header value for record {}: {}", record, header.value());
+                    }
+                }
+            }
+            return -1L;
+        }
+    }
 
-	private byte[] jsonValue(SinkRecord sinkRecord) {
-		Object value = sinkRecord.value();
-		if (value instanceof byte[]) {
-			return (byte[]) value;
-		}
-		if (value instanceof String) {
-			return ((String) value).getBytes(config.getCharset());
-		}
-		return jsonConverter.fromConnectData(sinkRecord.topic(), sinkRecord.valueSchema(), value);
-	}
+    private Collection<ScoredValue<byte[]>> scoredValues(SinkRecord sinkRecord) {
+        return Arrays.asList(ScoredValue.just(doubleValue(sinkRecord), member(sinkRecord)));
+    }
 
-	private Long longMember(SinkRecord sinkRecord) {
-		Object key = sinkRecord.key();
-		if (key == null) {
-			return null;
-		}
-		if (key instanceof Number) {
-			return ((Number) key).longValue();
-		}
-		throw new DataException(
-				"The key for the record must be a number. Consider using a single message transformation to transform the data before it is written to Redis.");
-	}
+    private Collection<Sample> samples(SinkRecord sinkRecord) {
+        return Arrays.asList(Sample.of(longMember(sinkRecord), doubleValue(sinkRecord)));
+    }
 
-	private Double doubleValue(SinkRecord sinkRecord) {
-		Object value = sinkRecord.value();
-		if (value == null) {
-			return null;
-		}
-		if (value instanceof Number) {
-			return ((Number) value).doubleValue();
-		}
-		throw new DataException(
-				"The value for the record must be a number. Consider using a single message transformation to transform the data before it is written to Redis.");
-	}
+    private byte[] value(SinkRecord sinkRecord) {
+        return bytes("value", sinkRecord.value());
+    }
 
-	private byte[] key(SinkRecord sinkRecord) {
-		if (config.getKeyspace().isEmpty()) {
-			return bytes("key", sinkRecord.key());
-		}
-		String keyspace = keyspace(sinkRecord);
-		String key = keyspace + config.getSeparator() + String.valueOf(sinkRecord.key());
-		return key.getBytes(config.getCharset());
-	}
+    private byte[] jsonValue(SinkRecord sinkRecord) {
+        Object value = sinkRecord.value();
+        if (value instanceof byte[]) {
+            return (byte[]) value;
+        }
+        if (value instanceof String) {
+            return ((String) value).getBytes(config.getCharset());
+        }
+        return jsonConverter.fromConnectData(sinkRecord.topic(), sinkRecord.valueSchema(), value);
+    }
 
-	private Collection<byte[]> members(SinkRecord sinkRecord) {
-		return Arrays.asList(member(sinkRecord));
-	}
+    private Long longMember(SinkRecord sinkRecord) {
+        Object key = sinkRecord.key();
+        if (key == null) {
+            return null;
+        }
+        if (key instanceof Number) {
+            return ((Number) key).longValue();
+        }
+        throw new DataException(
+                "The key for the record must be a number. Consider using a single message transformation to transform the data before it is written to Redis.");
+    }
 
-	private byte[] member(SinkRecord sinkRecord) {
-		return bytes("key", sinkRecord.key());
-	}
+    private Double doubleValue(SinkRecord sinkRecord) {
+        Object value = sinkRecord.value();
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        throw new DataException(
+                "The value for the record must be a number. Consider using a single message transformation to transform the data before it is written to Redis.");
+    }
 
-	private String keyspace(SinkRecord sinkRecord) {
-		return config.getKeyspace().replace(RedisSinkConfigDef.TOKEN_TOPIC, sinkRecord.topic());
-	}
+    private byte[] key(SinkRecord sinkRecord) {
+        if (config.getKeyspace().isEmpty()) {
+            return bytes("key", sinkRecord.key());
+        }
+        String keyspace = keyspace(sinkRecord);
+        String key = keyspace + config.getSeparator() + String.valueOf(sinkRecord.key());
+        return key.getBytes(config.getCharset());
+    }
 
-	private byte[] bytes(String source, Object input) {
-		if (input instanceof byte[]) {
-			return (byte[]) input;
-		}
-		if (input instanceof String) {
-			return ((String) input).getBytes(config.getCharset());
-		}
-		throw new DataException(String.format(
-				"The %s for the record must be a string or byte array. Consider using the StringConverter or ByteArrayConverter if the data is stored in Kafka in the format needed in Redis.",
-				source));
-	}
+    private Collection<byte[]> members(SinkRecord sinkRecord) {
+        return Arrays.asList(member(sinkRecord));
+    }
 
-	private byte[] collectionKey(SinkRecord sinkRecord) {
-		return keyspace(sinkRecord).getBytes(config.getCharset());
-	}
+    private byte[] member(SinkRecord sinkRecord) {
+        return bytes("key", sinkRecord.key());
+    }
 
-	private Collection<StreamMessage<byte[], byte[]>> streamMessages(SinkRecord sinkRecord) {
-		return Arrays.asList(new StreamMessage<>(collectionKey(sinkRecord), null, map(sinkRecord)));
-	}
+    private String keyspace(SinkRecord sinkRecord) {
+        return config.getKeyspace().replace(RedisSinkConfigDef.TOKEN_TOPIC, sinkRecord.topic());
+    }
 
-	@SuppressWarnings("unchecked")
-	private Map<byte[], byte[]> map(SinkRecord sinkRecord) {
-		Object value = sinkRecord.value();
-		if (value instanceof Struct) {
-			Map<byte[], byte[]> body = new LinkedHashMap<>();
-			Struct struct = (Struct) value;
-			for (Field field : struct.schema().fields()) {
-				Object fieldValue = struct.get(field);
-				body.put(field.name().getBytes(config.getCharset()),
-						fieldValue == null ? null : fieldValue.toString().getBytes(config.getCharset()));
-			}
-			return body;
-		}
-		if (value instanceof Map) {
-			Map<String, Object> map = (Map<String, Object>) value;
-			Map<byte[], byte[]> body = new LinkedHashMap<>();
-			for (Map.Entry<String, Object> e : map.entrySet()) {
-				body.put(e.getKey().getBytes(config.getCharset()),
-						String.valueOf(e.getValue()).getBytes(config.getCharset()));
-			}
-			return body;
-		}
-		throw new ConnectException("Unsupported source value type: " + sinkRecord.valueSchema().type().name());
-	}
+    private byte[] bytes(String source, Object input) {
+        if (input instanceof byte[]) {
+            return (byte[]) input;
+        }
+        if (input instanceof String) {
+            return ((String) input).getBytes(config.getCharset());
+        }
+        throw new DataException(String.format(
+                "The %s for the record must be a string or byte array. Consider using the StringConverter or ByteArrayConverter if the data is stored in Kafka in the format needed in Redis.",
+                source));
+    }
 
-	@Override
-	public void stop() {
-		if (writer != null) {
-			writer.close();
-		}
-		if (connection != null) {
-			connection.close();
-		}
-		if (client != null) {
-			client.shutdown();
-			client.getResources().shutdown();
-		}
-	}
+    private byte[] collectionKey(SinkRecord sinkRecord) {
+        return keyspace(sinkRecord).getBytes(config.getCharset());
+    }
 
-	@Override
-	public void put(final Collection<SinkRecord> records) {
-		log.debug("Processing {} records", records.size());
-		try {
-			writer.write(new Chunk<>(new ArrayList<>(records)));
-		} catch (RedisConnectionException e) {
-			throw new RetriableException("Could not get connection to Redis", e);
-		} catch (RedisCommandTimeoutException e) {
-			throw new RetriableException("Timeout while writing sink records", e);
-		} catch (Exception e) {
-			throw new RetriableException("Could not write sink records", e);
-		}
-		log.info("Wrote {} records", records.size());
-	}
+    private Collection<StreamMessage<byte[], byte[]>> streamMessages(SinkRecord sinkRecord) {
+        return Arrays.asList(new StreamMessage<>(collectionKey(sinkRecord), null, map(sinkRecord)));
+    }
 
-	@Override
-	public void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
-		Map<String, String> offsets = currentOffsets.entrySet().stream().map(this::offsetState)
-				.collect(offsetCollector);
-		log.trace("Writing offsets: {}", offsets);
-		try {
-			connection.sync().mset(offsets);
-		} catch (RedisCommandTimeoutException e) {
-			throw new RetriableException("Could not write offsets", e);
-		}
-	}
+    @SuppressWarnings("unchecked")
+    private Map<byte[], byte[]> map(SinkRecord sinkRecord) {
+        Object value = sinkRecord.value();
+        if (value instanceof Struct) {
+            Map<byte[], byte[]> body = new LinkedHashMap<>();
+            Struct struct = (Struct) value;
+            for (Field field : struct.schema().fields()) {
+                Object fieldValue = struct.get(field);
+                body.put(field.name().getBytes(config.getCharset()),
+                        fieldValue == null ? null : fieldValue.toString().getBytes(config.getCharset()));
+            }
+            return body;
+        }
+        if (value instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) value;
+            Map<byte[], byte[]> body = new LinkedHashMap<>();
+            for (Map.Entry<String, Object> e : map.entrySet()) {
+                body.put(e.getKey().getBytes(config.getCharset()),
+                        String.valueOf(e.getValue()).getBytes(config.getCharset()));
+            }
+            return body;
+        }
+        throw new ConnectException("Unsupported source value type: " + sinkRecord.valueSchema().type().name());
+    }
 
-	private SinkOffsetState offsetState(Entry<TopicPartition, OffsetAndMetadata> entry) {
-		return SinkOffsetState.of(entry.getKey(), entry.getValue().offset());
-	}
+    @Override
+    public void stop() {
+        if (writer != null) {
+            writer.close();
+        }
+        if (connection != null) {
+            connection.close();
+        }
+        if (client != null) {
+            client.shutdown();
+            client.getResources().shutdown();
+        }
+    }
 
-	private static String offsetKey(SinkOffsetState state) {
-		return offsetKey(state.topic(), state.partition());
-	}
+    @Override
+    public void put(final Collection<SinkRecord> records) {
+        log.debug("Processing {} records", records.size());
+        try {
+            writer.write(new Chunk<>(new ArrayList<>(records)));
+        } catch (RedisConnectionException e) {
+            throw new RetriableException("Could not get connection to Redis", e);
+        } catch (RedisCommandTimeoutException e) {
+            throw new RetriableException("Timeout while writing sink records", e);
+        } catch (Exception e) {
+            throw new RetriableException("Could not write sink records", e);
+        }
+        log.info("Wrote {} records", records.size());
+    }
 
-	private static String offsetValue(SinkOffsetState state) {
-		try {
-			return objectMapper.writeValueAsString(state);
-		} catch (JsonProcessingException e) {
-			throw new DataException("Could not serialize sink offset state", e);
-		}
-	}
+    @Override
+    public void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
+        Map<String, String> offsets = currentOffsets.entrySet().stream().map(this::offsetState)
+                .collect(offsetCollector);
+        log.trace("Writing offsets: {}", offsets);
+        try {
+            connection.sync().mset(offsets);
+        } catch (RedisCommandTimeoutException e) {
+            throw new RetriableException("Could not write offsets", e);
+        }
+    }
+
+    private SinkOffsetState offsetState(Entry<TopicPartition, OffsetAndMetadata> entry) {
+        return SinkOffsetState.of(entry.getKey(), entry.getValue().offset());
+    }
+
+    private class ConditionalDel implements Operation<byte[], byte[], SinkRecord, Object> {
+
+        private final Predicate<SinkRecord> delPredicate = r -> r.value() == null;
+        private final Operation<byte[], byte[], SinkRecord, Object> write;
+        private final Operation<byte[], byte[], SinkRecord, Object> del;
+
+        public ConditionalDel(Operation<byte[], byte[], SinkRecord, Object> delegate,
+                              Operation<byte[], byte[], SinkRecord, Object> remove) {
+            this.write = delegate;
+            this.del = remove;
+        }
+
+        @Override
+        public List<RedisFuture<Object>> execute(RedisAsyncCommands<byte[], byte[]> commands,
+                                                 Chunk<? extends SinkRecord> items) {
+            List<RedisFuture<Object>> futures = new ArrayList<>();
+            List<SinkRecord> toRemove = items.getItems().stream().filter(delPredicate).collect(Collectors.toList());
+            futures.addAll(del.execute(commands, new Chunk<>(toRemove)));
+            List<SinkRecord> toWrite = items.getItems().stream().filter(delPredicate.negate())
+                    .collect(Collectors.toList());
+            futures.addAll(write.execute(commands, new Chunk<>(toWrite)));
+            return futures;
+        }
+
+    }
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,8 +79,6 @@ services:
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
-    volumes:
-      - ./core/redis-kafka-connect/build/confluentArchive/redis-redis-kafka-connect-1.0.0-SNAPSHOT:/usr/share/confluent-hub-components/redis-redis-kafka-connect
     healthcheck:
       interval: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,45 +1,38 @@
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.2.0
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:7.2.0
+    image: confluentinc/cp-kafka:7.7.0
     hostname: broker
     container_name: broker
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
       - "9101:9101"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_JMX_PORT: 9101
       KAFKA_JMX_HOSTNAME: localhost
-      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      CONFLUENT_METRICS_ENABLE: 'true'
-      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@broker:29093'
+      KAFKA_LISTENERS: 'PLAINTEXT://broker:29092,CONTROLLER://broker:29093,PLAINTEXT_HOST://0.0.0.0:9092'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+      # Replace CLUSTER_ID with a unique base64 UUID using "bin/kafka-storage.sh random-uuid"
+      # See https://docs.confluent.io/kafka/operations-tools/kafka-tools.html#kafka-storage-sh
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+    healthcheck:
+      test: echo srvr | nc broker 9092 || exit 1
+      interval: 5s
+      retries: 10
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.2.0
+    image: confluentinc/cp-schema-registry:7.7.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -50,9 +43,13 @@ services:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:8081
 
   connect:
-    #image: fieldengineering/redis-kafka-connect
+    image: fieldengineering/redis-kafka-connect
     build:
       context: .
     hostname: connect
@@ -82,9 +79,15 @@ services:
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
       CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
       CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
+    volumes:
+      - ./core/redis-kafka-connect/build/confluentArchive/redis-redis-kafka-connect-1.0.0-SNAPSHOT:/usr/share/confluent-hub-components/redis-redis-kafka-connect
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:8083
 
   control-center:
-    image: confluentinc/cp-enterprise-control-center:7.2.0
+    image: confluentinc/cp-enterprise-control-center:7.7.0
     hostname: control-center
     container_name: control-center
     depends_on:
@@ -105,9 +108,13 @@ services:
       CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
       CONFLUENT_METRICS_TOPIC_REPLICATION: 1
       PORT: 9021
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:9021
 
   ksqldb-server:
-    image: confluentinc/cp-ksqldb-server:7.2.0
+    image: confluentinc/cp-ksqldb-server:7.7.0
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -128,9 +135,13 @@ services:
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_REPLICATION_FACTOR: 1
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: 'true'
       KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: 'true'
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:8088
 
   rest-proxy:
-    image: confluentinc/cp-kafka-rest:7.2.0
+    image: confluentinc/cp-kafka-rest:7.7.0
     depends_on:
       - broker
       - schema-registry
@@ -143,10 +154,20 @@ services:
       KAFKA_REST_BOOTSTRAP_SERVERS: 'broker:29092'
       KAFKA_REST_LISTENERS: "http://0.0.0.0:8082"
       KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
-      
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:8082
+
   redis:
     image: redis/redis-stack-server
     hostname: redis
     container_name: redis
     ports:
       - "6379:6379"
+    healthcheck:
+      test: [ "CMD-SHELL", "redis-cli ping | grep PONG" ]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+      timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,9 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   connect:
-    image: fieldengineering/redis-kafka-connect
+    #image: fieldengineering/redis-kafka-connect
+    build:
+      context: .
     hostname: connect
     container_name: connect
     depends_on:

--- a/run.sh
+++ b/run.sh
@@ -86,7 +86,8 @@ curl -X POST -H "Content-Type: application/json" --data '
      "redis.uri": "redis://redis:6379",
      "key.converter": "org.apache.kafka.connect.storage.StringConverter",
      "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-     "value.converter.schemas.enable": "false"
+     "value.converter.schemas.enable": "false",
+     "redis.key.ttl": "3600"
 }}' http://localhost:8083/connectors -w "\n"
 
 sleep 2


### PR DESCRIPTION
This PR adds support for setting TTL values into Redis keys, either at a record level or via configuration. If set at a record level, this means Kafka producers or SMT processors can be used to set the value `redis.key.ttl` on a per-record basis. Otherwise, users can also specify this property via connector configuration, in which the value will be set to any record written into Redis. If both record-level and configuration-level values are set, then record-level takes precedence.

This PR also upgrades the Docker Compose file with newer versions of Kafka, health checks for containers, and an updated Dockerfile to build Kafka Connect.