### PR TITLE
Update Redis image to use latest redis 8 version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,7 +158,7 @@ services:
       test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:8082
 
   redis:
-    image: redis/redis-stack-server
+    image: redis:latest
     hostname: redis
     container_name: redis
     ports:


### PR DESCRIPTION
This change updates the Redis service in docker-compose.yml to use the latest Redis 8 image instead of the previous Redis Stack image. The goal is to align the local development environment with the version of Redis that customers are running and simplify the demo setup.