### PR TITLE
Fix Redis Sentinel connection issue by preserving Sentinel Master ID and Hosts in RedisConfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ ARG CP_VERSION=7.7.0
 ARG BASE_PREFIX=confluentinc
 ARG CONNECT_IMAGE=cp-kafka-connect
 
-FROM openjdk:18-jdk-slim AS build
-WORKDIR /root/redis-kafka-connect
-COPY . /root/redis-kafka-connect
-RUN ./gradlew createConfluentArchive
+FROM gradle:8.10.0-jdk17 AS build
+WORKDIR /app
+COPY --chown=gradle:gradle . /app
+RUN gradle createConfluentArchive --no-daemon
 
 FROM $BASE_PREFIX/$CONNECT_IMAGE:$CP_VERSION
 
-COPY --from=build /root/redis-kafka-connect/core/redis-kafka-connect/build/confluent/redis-redis-kafka-connect-*.zip /tmp/redis-redis-kafka-connect.zip
+COPY --from=build /app/core/redis-kafka-connect/build/confluent/redis-redis-kafka-connect-*.zip /tmp/redis-redis-kafka-connect.zip
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/common/RedisConfig.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/common/RedisConfig.java
@@ -73,7 +73,15 @@ public abstract class RedisConfig extends AbstractConfig {
     private RedisURI.Builder redisURIBuilder() {
         String uri = getString(RedisConfigDef.URI_CONFIG);
         if (StringUtils.hasLength(uri)) {
-            return RedisURI.builder(RedisURI.create(uri));
+            RedisURI redisURI = RedisURI.create(uri);
+            RedisURI.Builder builder = RedisURI.builder(redisURI);
+            if (StringUtils.hasLength(redisURI.getSentinelMasterId())) {
+                builder.withSentinelMasterId(redisURI.getSentinelMasterId());
+                for (RedisURI sentinel : redisURI.getSentinels()) {
+                    builder.withSentinel(sentinel.getHost(), sentinel.getPort());
+                }
+            }
+            return builder;
         }
         String host = getString(RedisConfigDef.HOST_CONFIG);
         int port = getInt(RedisConfigDef.PORT_CONFIG);

--- a/core/redis-kafka-connect/src/test/java/com/redis/kafka/connect/StreamSourceConnectorTest.java
+++ b/core/redis-kafka-connect/src/test/java/com/redis/kafka/connect/StreamSourceConnectorTest.java
@@ -97,4 +97,17 @@ class StreamSourceConnectorTest {
 
 	}
 
+	@Test
+	void testRedisSentinelValueConfig() {
+		final Map<String, String> props = new HashMap<>();
+		props.put(RedisConfigDef.URI_CONFIG, "redis-sentinel://localhost:26379,localhost:26380#mymaster");
+		props.put(RedisStreamSourceConfigDef.STREAM_NAME_CONFIG, "stream");
+
+		RedisStreamSourceConfig config = new RedisStreamSourceConfig(props);
+		RedisURI redisURI = config.uri();
+
+		assertEquals("mymaster", redisURI.getSentinelMasterId());
+		assertEquals(2, redisURI.getSentinels().size());
+	}
+
 }


### PR DESCRIPTION
## Summary
**This PR addresses two key issues:**

**Sentinel Connection:** Fixes a bug where configuring a [redis-sentinel] URI failed to establish a connection to the Redis Master because the Sentinel Master ID and Host details were lost during configuration parsing.

**Build Environment:** Updates the [Dockerfile] to use a supported Gradle image, as the previous OpenJDK image is deprecated and was causing build failures.

## Changes
**Modified [RedisConfig.java]:** Updated [redisURIBuilder()] to explicitly check for sentinelMasterId and sentinels in the parsed URI. If present, they are now manually added to the [RedisURI.Builder] to ensure the final URI is correctly configured for Sentinel mode.

**Updated [Dockerfile]:** Replaced the deprecated openjdk:18-jdk-slim build image with gradle:8.10.0-jdk17. This fixes ./gradlew execution issues and ensures a stable build environment compatible with the project's Java 17 requirement.

**Added Unit Test:** Added [testRedisSentinelValueConfig] in [StreamSourceConnectorTest.java] to verify that [redis-sentinel] URIs are correctly parsed and that the Master ID and Sentinel hosts are preserved.

## Testing
**Unit Testing:** Verified with the new test case [StreamSourceConnectorTest.testRedisSentinelValueConfig].

**Integration Testing:** Validated in a local Docker Compose environment with a dedicated Redis Sentinel setup.
Confirmed successful connection for both Sink and Source connectors using [redis-sentinel://] URIs.
Verified password authentication and consumer group functionality with Sentinel.

**Build Verification:** Confirmed that the project builds successfully with the new Dockerfile configuration.

## Related Issue
Fixes [java.lang.IllegalStateException: Cannot build a RedisURI. One of the following must be provided Host, Socket or Sentinel] when using Sentinel and resolves build failures due to deprecated base images.