### PR TITLE
chore: Fix JReleaser signing deprecation warning

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -50,7 +50,8 @@ release:
 
 signing:
   active: ALWAYS
-  armored: true
+  pgp:
+    armored: true
 
 announce:
   slack:


### PR DESCRIPTION
Replace deprecated `signing.armored` with `signing.pgp.armored` to address JReleaser 1.22.0 deprecation warning and ensure compatibility with JReleaser 2.0.0.

## Changes
- Updated `jreleaser.yml` to use `signing.pgp.armored` instead of deprecated `signing.armored`

## Context
JReleaser 1.22.0 deprecated `signing.armored` in favor of `signing.pgp.armored`. This change will be required for JReleaser 2.0.0 compatibility.