### PR TITLE
fix sink offset restore lifecycle

### DIFF
--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfig.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfig.java
@@ -20,6 +20,8 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 
+import org.springframework.util.StringUtils;
+
 import com.redis.kafka.connect.common.RedisConfig;
 
 public class RedisSinkConfig extends RedisConfig {
@@ -38,6 +40,7 @@ public class RedisSinkConfig extends RedisConfig {
 	private final int waitReplicas;
 	private final Duration waitTimeout;
 	private final long keyTTL;
+	private final String offsetNamespace;
 
 	public RedisSinkConfig(Map<?, ?> originals) {
 		super(new RedisSinkConfigDef(), originals);
@@ -50,6 +53,19 @@ public class RedisSinkConfig extends RedisConfig {
 		waitReplicas = getInt(RedisSinkConfigDef.WAIT_REPLICAS_CONFIG);
 		waitTimeout = Duration.ofMillis(getLong(RedisSinkConfigDef.WAIT_TIMEOUT_CONFIG));
 		keyTTL = getLong(RedisSinkConfigDef.KEY_TTL_CONFIG);
+		offsetNamespace = offsetNamespace(originals);
+	}
+
+	private String offsetNamespace(Map<?, ?> originals) {
+		String namespace = getString(RedisSinkConfigDef.OFFSET_NAMESPACE_CONFIG).trim();
+		if (StringUtils.hasText(namespace)) {
+			return namespace;
+		}
+		Object connectorName = originals.get("name");
+		if (connectorName != null && StringUtils.hasText(connectorName.toString())) {
+			return connectorName.toString().trim();
+		}
+		return "default";
 	}
 
 	public Charset getCharset() {
@@ -84,12 +100,17 @@ public class RedisSinkConfig extends RedisConfig {
 		return keyTTL;
 	}
 
+	public String getOffsetNamespace() {
+		return offsetNamespace;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result
-				+ Objects.hash(charset, keyspace, separator, multiExec, type, waitReplicas, waitTimeout, keyTTL);
+				+ Objects.hash(charset, keyspace, separator, multiExec, type, waitReplicas, waitTimeout, keyTTL,
+						offsetNamespace);
 		return result;
 	}
 
@@ -104,7 +125,8 @@ public class RedisSinkConfig extends RedisConfig {
 		RedisSinkConfig other = (RedisSinkConfig) obj;
 		return Objects.equals(charset, other.charset) && Objects.equals(keyspace, other.keyspace)
 				&& Objects.equals(separator, other.separator) && multiExec == other.multiExec && type == other.type
-				&& waitReplicas == other.waitReplicas && waitTimeout == other.waitTimeout && keyTTL == other.keyTTL;
+				&& waitReplicas == other.waitReplicas && waitTimeout == other.waitTimeout && keyTTL == other.keyTTL
+				&& Objects.equals(offsetNamespace, other.offsetNamespace);
 	}
 
 }

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfigDef.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkConfigDef.java
@@ -67,6 +67,12 @@ public class RedisSinkConfigDef extends RedisConfigDef {
 
 	public static final String KEY_TTL_CONFIG_DOC = "Time to live in seconds for the key. If not set, the record will not expire.";
 
+	public static final String OFFSET_NAMESPACE_CONFIG = "redis.offset.namespace";
+
+	public static final String OFFSET_NAMESPACE_DEFAULT = "";
+
+	public static final String OFFSET_NAMESPACE_DOC = "Namespace for sink offset keys stored in Redis. If empty, the connector name is used.";
+
 	protected static final Set<RedisType> MULTI_EXEC_COMMANDS = Stream
 			.of(RedisType.STREAM, RedisType.LIST, RedisType.SET, RedisType.ZSET).collect(Collectors.toSet());
 
@@ -88,6 +94,7 @@ public class RedisSinkConfigDef extends RedisConfigDef {
 		define(WAIT_REPLICAS_CONFIG, Type.INT, WAIT_REPLICAS_DEFAULT, Importance.MEDIUM, WAIT_REPLICAS_DOC);
 		define(WAIT_TIMEOUT_CONFIG, Type.LONG, WAIT_TIMEOUT_DEFAULT, Importance.MEDIUM, WAIT_TIMEOUT_DOC);
 		define(KEY_TTL_CONFIG, Type.LONG, KEY_TTL_CONFIG_DEFAULT, Importance.MEDIUM, KEY_TTL_CONFIG_DOC);
+		define(OFFSET_NAMESPACE_CONFIG, Type.STRING, OFFSET_NAMESPACE_DEFAULT, Importance.MEDIUM, OFFSET_NAMESPACE_DOC);
 	}
 
 	@Override

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/sink/RedisSinkTask.java
@@ -47,24 +47,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.util.CollectionUtils;
 
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Predicate;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class RedisSinkTask extends SinkTask {
 
     private static final Logger log = LoggerFactory.getLogger(RedisSinkTask.class);
 
-    private static final String OFFSET_KEY_FORMAT = "com.redis.kafka.connect.sink.offset.%s.%s";
+    private static final String OFFSET_KEY_FORMAT = "com.redis.kafka.connect.sink.offset.%s.%s.%s";
+
+    private static final String LEGACY_OFFSET_KEY_FORMAT = "com.redis.kafka.connect.sink.offset.%s.%s";
 
     private static final ObjectMapper objectMapper = objectMapper();
-
-    private static final Collector<SinkOffsetState, ?, Map<String, String>> offsetCollector = Collectors
-            .toMap(RedisSinkTask::offsetKey, RedisSinkTask::offsetValue);
 
     private RedisSinkConfig config;
 
@@ -79,14 +76,6 @@ public class RedisSinkTask extends SinkTask {
         mapper.configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
         mapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
         return mapper;
-    }
-
-    private static String offsetKey(String topic, Integer partition) {
-        return String.format(OFFSET_KEY_FORMAT, topic, partition);
-    }
-
-    private static String offsetKey(SinkOffsetState state) {
-        return offsetKey(state.topic(), state.partition());
     }
 
     private static String offsetValue(SinkOffsetState state) {
@@ -116,17 +105,25 @@ public class RedisSinkTask extends SinkTask {
         writer.setWaitTimeout(config.getWaitTimeout());
         writer.setPoolSize(config.getPoolSize());
         writer.open(new ExecutionContext());
-        java.util.Set<TopicPartition> assignment = this.context.assignment();
-        if (CollectionUtils.isEmpty(assignment)) {
+    }
+
+    @Override
+    public void open(Collection<TopicPartition> partitions) {
+        super.open(partitions);
+        if (partitions.isEmpty()) {
             return;
         }
+        restoreOffsets(partitions);
+    }
+
+    private void restoreOffsets(Collection<TopicPartition> assignment) {
         Map<TopicPartition, Long> partitionOffsets = new HashMap<>(assignment.size());
         for (SinkOffsetState state : offsetStates(assignment)) {
             partitionOffsets.put(state.topicPartition(), state.offset());
             log.info("Requesting offset {} for {}", state.offset(), state.topicPartition());
         }
-        for (TopicPartition topicPartition : assignment) {
-            partitionOffsets.putIfAbsent(topicPartition, 0L);
+        if (partitionOffsets.isEmpty()) {
+            return;
         }
         this.context.offset(partitionOffsets);
     }
@@ -142,19 +139,45 @@ public class RedisSinkTask extends SinkTask {
         }
     }
 
-    private Collection<SinkOffsetState> offsetStates(java.util.Set<TopicPartition> assignment) {
-        String[] partitionKeys = assignment.stream().map(this::offsetKey).toArray(String[]::new);
-        List<KeyValue<String, String>> values = connection.sync().mget(partitionKeys);
-        return values.stream().filter(KeyValue::hasValue).map(this::offsetState).collect(Collectors.toList());
+    private Collection<SinkOffsetState> offsetStates(Collection<TopicPartition> assignment) {
+        return assignment.stream().map(this::offsetState).filter(Optional::isPresent).map(Optional::get)
+                .collect(Collectors.toList());
+    }
+
+    private Optional<SinkOffsetState> offsetState(TopicPartition partition) {
+        String value = connection.sync().get(offsetKey(partition));
+        if (value == null) {
+            value = connection.sync().get(legacyOffsetKey(partition));
+        }
+        if (value == null) {
+            return Optional.empty();
+        }
+        SinkOffsetState state = offsetState(value);
+        if (!partition.equals(state.topicPartition())) {
+            throw new DataException("Sink offset state does not match partition " + partition);
+        }
+        return Optional.of(state);
     }
 
     private String offsetKey(TopicPartition partition) {
         return offsetKey(partition.topic(), partition.partition());
     }
 
-    private SinkOffsetState offsetState(KeyValue<String, String> value) {
+    private String offsetKey(SinkOffsetState state) {
+        return offsetKey(state.topic(), state.partition());
+    }
+
+    private String offsetKey(String topic, Integer partition) {
+        return String.format(OFFSET_KEY_FORMAT, config.getOffsetNamespace(), topic, partition);
+    }
+
+    private String legacyOffsetKey(TopicPartition partition) {
+        return String.format(LEGACY_OFFSET_KEY_FORMAT, partition.topic(), partition.partition());
+    }
+
+    private SinkOffsetState offsetState(String value) {
         try {
-            return objectMapper.readValue(value.getValue(), SinkOffsetState.class);
+            return objectMapper.readValue(value, SinkOffsetState.class);
         } catch (JsonProcessingException e) {
             throw new DataException("Could not parse sink offset state", e);
         }
@@ -369,7 +392,10 @@ public class RedisSinkTask extends SinkTask {
     @Override
     public void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
         Map<String, String> offsets = currentOffsets.entrySet().stream().map(this::offsetState)
-                .collect(offsetCollector);
+                .collect(Collectors.toMap(this::offsetKey, RedisSinkTask::offsetValue));
+        if (offsets.isEmpty()) {
+            return;
+        }
         log.trace("Writing offsets: {}", offsets);
         try {
             connection.sync().mset(offsets);

--- a/core/redis-kafka-connect/src/test/java/com/redis/kafka/connect/AbstractSinkIntegrationTests.java
+++ b/core/redis-kafka-connect/src/test/java/com/redis/kafka/connect/AbstractSinkIntegrationTests.java
@@ -1,7 +1,10 @@
 package com.redis.kafka.connect;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
@@ -16,6 +19,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
@@ -56,6 +60,10 @@ abstract class AbstractSinkIntegrationTests extends AbstractTestBase {
 
     public static final long TIMESTAMP = 1530286549123L;
 
+    private static final String OFFSET_KEY_FORMAT = "com.redis.kafka.connect.sink.offset.%s.%s.%s";
+
+    private static final String LEGACY_OFFSET_KEY_FORMAT = "com.redis.kafka.connect.sink.offset.%s.%s";
+
     public static SinkRecord write(String topic, SchemaAndValue key, SchemaAndValue value) {
         Preconditions.notNull(topic, "topic cannot be null");
         Preconditions.notNull(key, "key cannot be null.");
@@ -75,6 +83,22 @@ abstract class AbstractSinkIntegrationTests extends AbstractTestBase {
             body.put(args[index * 2], args[index * 2 + 1]);
         }
         return body;
+    }
+
+    private Map<String, String> sinkProps(String connectorName) {
+        return ImmutableMap.of("name", connectorName, RedisSinkConfigDef.URI_CONFIG, getRedisServer().getRedisURI());
+    }
+
+    private static String offsetKey(String namespace, TopicPartition topicPartition) {
+        return String.format(OFFSET_KEY_FORMAT, namespace, topicPartition.topic(), topicPartition.partition());
+    }
+
+    private static String legacyOffsetKey(TopicPartition topicPartition) {
+        return String.format(LEGACY_OFFSET_KEY_FORMAT, topicPartition.topic(), topicPartition.partition());
+    }
+
+    private static String offsetValue(String topic, int partition, long offset) {
+        return "{\"topic\":\"" + topic + "\",\"partition\":" + partition + ",\"offset\":" + offset + "}";
     }
 
     private RedisSinkTask task;
@@ -103,10 +127,88 @@ abstract class AbstractSinkIntegrationTests extends AbstractTestBase {
     void putEmpty() {
         String topic = "putWrite";
         SinkTaskContext context = mock(SinkTaskContext.class);
-        when(context.assignment()).thenReturn(ImmutableSet.of(new TopicPartition(topic, 1)));
         this.task.initialize(context);
         this.task.start(ImmutableMap.of(RedisSinkConfigDef.URI_CONFIG, getRedisServer().getRedisURI()));
         this.task.put(ImmutableList.of());
+    }
+
+    @Test
+    void flushWritesNamespacedOffset() throws JsonProcessingException {
+        String topic = "flushWritesNamespacedOffset";
+        TopicPartition topicPartition = new TopicPartition(topic, PARTITION);
+        SinkTaskContext context = mock(SinkTaskContext.class);
+        this.task.initialize(context);
+        this.task.start(sinkProps("connector-a"));
+
+        this.task.flush(ImmutableMap.of(topicPartition, new OffsetAndMetadata(123L)));
+
+        String value = redisConnection.sync().get(offsetKey("connector-a", topicPartition));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> offset = new ObjectMapper().readValue(value, Map.class);
+        assertEquals(topic, offset.get("topic"));
+        assertEquals(PARTITION, offset.get("partition"));
+        assertEquals(123, offset.get("offset"));
+    }
+
+    @Test
+    void openRestoresNamespacedOffset() {
+        String topic = "openRestoresNamespacedOffset";
+        TopicPartition topicPartition = new TopicPartition(topic, PARTITION);
+        redisConnection.sync().set(offsetKey("connector-a", topicPartition), offsetValue(topic, PARTITION, 456L));
+        SinkTaskContext context = mock(SinkTaskContext.class);
+        this.task.initialize(context);
+        this.task.start(sinkProps("connector-a"));
+
+        this.task.open(ImmutableList.of(topicPartition));
+
+        verify(context).offset(ImmutableMap.of(topicPartition, 456L));
+    }
+
+    @Test
+    void openDoesNotSeekPartitionsWithoutStoredOffsets() {
+        TopicPartition topicPartition = new TopicPartition("openDoesNotSeekPartitionsWithoutStoredOffsets", PARTITION);
+        SinkTaskContext context = mock(SinkTaskContext.class);
+        this.task.initialize(context);
+        this.task.start(sinkProps("connector-a"));
+
+        this.task.open(ImmutableList.of(topicPartition));
+
+        verify(context, never()).offset(anyMap());
+    }
+
+    @Test
+    void openFallsBackToLegacyOffsetKey() {
+        String topic = "openFallsBackToLegacyOffsetKey";
+        TopicPartition topicPartition = new TopicPartition(topic, PARTITION);
+        redisConnection.sync().set(legacyOffsetKey(topicPartition), offsetValue(topic, PARTITION, 789L));
+        SinkTaskContext context = mock(SinkTaskContext.class);
+        this.task.initialize(context);
+        this.task.start(sinkProps("connector-a"));
+
+        this.task.open(ImmutableList.of(topicPartition));
+
+        verify(context).offset(ImmutableMap.of(topicPartition, 789L));
+    }
+
+    @Test
+    void offsetsAreScopedByNamespace() {
+        String topic = "offsetsAreScopedByNamespace";
+        TopicPartition topicPartition = new TopicPartition(topic, PARTITION);
+        SinkTaskContext context = mock(SinkTaskContext.class);
+        this.task.initialize(context);
+        this.task.start(sinkProps("connector-a"));
+
+        this.task.flush(ImmutableMap.of(topicPartition, new OffsetAndMetadata(11L)));
+        this.task.stop();
+        this.task = new RedisSinkTask();
+        this.task.initialize(context);
+        this.task.start(sinkProps("connector-b"));
+        this.task.flush(ImmutableMap.of(topicPartition, new OffsetAndMetadata(22L)));
+
+        Assertions.assertNotNull(redisConnection.sync().get(offsetKey("connector-a", topicPartition)));
+        Assertions.assertNotNull(redisConnection.sync().get(offsetKey("connector-b", topicPartition)));
+        Assertions.assertNotEquals(redisConnection.sync().get(offsetKey("connector-a", topicPartition)),
+                redisConnection.sync().get(offsetKey("connector-b", topicPartition)));
     }
 
     @Test

--- a/docs/guide/src/docs/asciidoc/sink.adoc
+++ b/docs/guide/src/docs/asciidoc/sink.adoc
@@ -311,13 +311,14 @@ topics           = <Kafka topic> <1>
 redis.uri        = <Redis URI> <2>
 redis.type       = <HASH|SET|JSON|STREAM|LIST|SET|ZSET|TIMESERIES> <3>
 redis.key.ttl    = <TTL in seconds> <4>
-key.converter    = <Key converter> <5>
-value.converter  = <Value converter> <6>
+redis.offset.namespace = <Offset namespace> <5>
+key.converter    = <Key converter> <6>
+value.converter  = <Value converter> <7>
 ----
 <1> Kafka topics to read messsages from.
 <2> <<_sink_redis_client,Redis URI>>.
 <3> <<_sink_redis_command,Redis command>>.
 <4> <<_sink_ttl,TTL in seconds>> (optional, default: -1 for no expiration).
-<5> <<_sink_key,Key converter>>.
-<6> <<_sink_value,Value converter>>.
-
+<5> Namespace for sink offset keys stored in Redis (optional, default: connector name).
+<6> <<_sink_key,Key converter>>.
+<7> <<_sink_value,Value converter>>.


### PR DESCRIPTION
## Summary

Fixes sink offset recovery by restoring Redis-backed offsets during partition assignment instead of task startup, and leaves partitions without Redis offsets on Kafka Connect's committed positions.
Adds a `redis.offset.namespace` option, defaulting to the connector name, so multiple sink connectors do not overwrite each other's Redis offset keys while still reading legacy offset keys as a fallback.
Adds integration coverage for namespaced offset writes, restore behavior, missing offsets, legacy fallback, and namespace isolation, and documents the new setting.

## Tests

`JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew -I .context/disable-buildinfo.gradle :redis-kafka-connect:compileTestJava :redis-kafka-connect:test --tests 'com.redis.kafka.connect.SinkConnectorTest'`

Full sink integration execution was blocked locally by Testcontainers Docker discovery returning HTTP 400 from the Docker socket before test bodies ran.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how consumer offsets are set after restarts; wrong behavior could duplicate or skip messages, though legacy key fallback limits migration risk.
> 
> **Overview**
> Fixes **Redis sink offset recovery** by moving restore from task `start()` to **`open()`** when partitions are assigned, matching Kafka Connect’s lifecycle. Partitions **without** a stored Redis offset are no longer forced to offset `0`; Connect keeps its committed position.
> 
> Adds **`redis.offset.namespace`** (default: connector `name`) so offset keys in Redis are **per-connector** and multiple sinks do not clobber each other. **Flush** writes namespaced keys; **restore** reads them and **falls back** to the prior two-segment key format for upgrades.
> 
> New integration tests cover namespaced flush/restore, no seek when missing, legacy keys, and namespace isolation; sink docs document the setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1d10ef6153456f09c0149d7c5920765f5124ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->